### PR TITLE
typo: fix mixin solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Possible objects based mixin solutions could also benefit from this proposal:
 ```js
 let mix = (object) => ({
   with: (...mixins) => mixins.reduce(
-    (c, mixin) => Object.create(
+    (c, mixin) => Object.defineProperties(
       c, Object.getOwnPropertyDescriptors(mixin)
     ), object)
 });


### PR DESCRIPTION
I think the better way to show a mixin solution is just to code like the following snippet:

```js
/** mixin solution */
const mix = obj => ({
    with : (...mixins) => mixins.reduce((c, mixin) => shallowMerge(c, mixin), obj),
});
```